### PR TITLE
changed key component html element from <li> to <button>

### DIFF
--- a/src/components/key.tsx
+++ b/src/components/key.tsx
@@ -12,7 +12,7 @@ interface StyledKeyProps {
     isPlaying : boolean,
 }
 
-const StyledKey = styled.li`
+const StyledKey = styled.button`
     display:flex;
     position:relative;
     float:left;
@@ -40,7 +40,7 @@ const StyledFlat = styled(StyledKey)`
     width: 4rem;
     background-color: ${(props: StyledKeyProps) => props.isPlaying ? playingNoteBackgroundColor :'rgb(20,20,20)'};
     color:${(props: StyledKeyProps) => props.isPlaying ? 'rgb(230,230,230)' : 'rgb(0,0,0)'};
-    margin:0 -2em;
+    margin:0 -3em;
     z-index: 2;
     &:hover{
         background-color:${(props: StyledKeyProps) => props.isPlaying ? playingNoteBackgroundColor: 'rgb(170,120,100)'};

--- a/src/components/keyboard.tsx
+++ b/src/components/keyboard.tsx
@@ -5,7 +5,7 @@ import Key from "./key";
 import ControlPanel from "./controlPanel"
 import { KeyboardProvider } from "../hooks/keyboardContext";
 
-const StyledKeys = styled.ul`
+const StyledKeys = styled.div`
     display: flex;
     margin:1rem 2rem 0 2rem;
     padding-inline-start: unset;


### PR DESCRIPTION
Safari mobile doesn't allow clicking on things that are not normally clickable, such as an `<li>`. `<button>`s are natively clickable