### PR TITLE
Add initial support for wavetables

### DIFF
--- a/src/classes/Voice.tsx
+++ b/src/classes/Voice.tsx
@@ -56,7 +56,6 @@ export default class Voice {
       const osc = this.audioContext.createOscillator();
       this.setWave(osc, wave, wavetable);
       osc.frequency.value = this.frequency;
-      osc.type = wave;
       osc.detune.value = this.getDetuneVal(i, this.detune);
       osc.connect(this.envelopeGain);
       osc.start();

--- a/src/classes/Voice.tsx
+++ b/src/classes/Voice.tsx
@@ -114,14 +114,8 @@ export default class Voice {
 
   setWave(osc: OscillatorNode, wave: OscillatorType, wavetable: Wavetable) {
     if (wave == getWave(waveforms.CUSTOM)) {
-      if (wavetable == null) {
-        console.log("Tried to set custom wavetable, but wavetable was null, will fall back to sine...");
-        osc.type = getWave(waveforms.SINE);
-      }
-      else {
-        var periodicWave = wavetable.getPeriodicWave(this.audioContext);
-        osc.setPeriodicWave(periodicWave);
-      }
+      var periodicWave = wavetable.getPeriodicWave(this.audioContext);
+      osc.setPeriodicWave(periodicWave);
     }
     else {
       osc.type = wave;

--- a/src/classes/Wavetable.tsx
+++ b/src/classes/Wavetable.tsx
@@ -1,0 +1,25 @@
+export default class Wavetable {
+    real: number[];
+    imag: number[];
+
+    constructor(
+        real: number[],
+        imag: number[]
+    ) {
+        this.real = real;
+        this.imag = imag;
+    }
+
+    static fromTimeData(sampleRate: number, timeData: number[]) {
+        // TODO: FFT on timeseries to get real / imag components
+        return new Wavetable([0, 1], [0, 0]);
+    }
+
+    static createEmpty() {
+        return new Wavetable([0], [0]);
+    }
+
+    getPeriodicWave(audioContext: AudioContext) {
+        return audioContext.createPeriodicWave(this.real, this.imag);
+    }
+}

--- a/src/classes/WavetableCache.tsx
+++ b/src/classes/WavetableCache.tsx
@@ -1,0 +1,40 @@
+import Wavetable from "./Wavetable";
+import wavetables from "../data/wavetables";
+
+export default class WavetableCache {
+    static singleton: WavetableCache;
+    cache: Map<string, Wavetable>;
+
+    constructor() {
+        this.cache = new Map<string, Wavetable>();
+    }
+
+    static getSingleton() {
+        if (WavetableCache.singleton == null) {
+            WavetableCache.singleton = new WavetableCache();
+        }
+
+        return WavetableCache.singleton;
+    }
+
+    get(name: string) {
+        var lowercaseName = name.toLowerCase();
+        if (this.cache.has(lowercaseName)) {
+            return this.cache.get(lowercaseName);
+        }
+        else {
+            return null;
+        }
+    }
+
+    add(name: string, wavetable: Wavetable) {
+        this.cache.set(name.toLowerCase(), wavetable);
+    }
+
+    init() {
+        wavetables.forEach((value: number[][], key: string) => {
+            var wavetable = new Wavetable(value[0], value[1]);
+            this.add(key, wavetable);
+        });
+    }
+}

--- a/src/classes/audioContextWrapper.tsx
+++ b/src/classes/audioContextWrapper.tsx
@@ -127,8 +127,18 @@ class AudioContextWrapper {
     this.waveform = newWaveform;
   }
 
-  set Wavetable(newWavetable: Wavetable) {
+  setWavetable(newWavetable: Wavetable) {
     this.wavetable = newWavetable;
+  }
+
+  setWavetableName(newWavetableName: string) {
+    var wavetableFromCache = WavetableCache.getSingleton().get(newWavetableName);
+    if (wavetableFromCache == null) {
+      console.log("Unable to find wavetable " + newWavetableName + " in the cache");
+      wavetableFromCache = Wavetable.createEmpty();
+    }
+
+    this.setWavetable(wavetableFromCache);
   }
 
   setOctave(octave: number) {

--- a/src/data/waveforms.tsx
+++ b/src/data/waveforms.tsx
@@ -3,6 +3,7 @@ enum waveforms {
   SQUARE,
   SAWTOOTH,
   TRIANGLE,
+  CUSTOM
 }
 
 export default waveforms;
@@ -23,6 +24,8 @@ export const getWave = (waveId: waveforms): OscillatorType => {
       return "sawtooth";
     case waveforms.TRIANGLE:
       return "triangle";
+    case waveforms.CUSTOM:
+      return "custom";
     case waveforms.SINE:
     default:
       return "sine";

--- a/src/data/wavetables.tsx
+++ b/src/data/wavetables.tsx
@@ -1,0 +1,7 @@
+// map of wavetable name to list of arrays (real / imag)
+const wavetables: Map<string, number[][]> = new Map([
+    ["sine", [[0, 1], [0, 0]]],
+    ["organ", [[0, 1, 0, 0, 1.5, 0, 0.1, 0, 0, 1], [0, 0, 0, 1, 0, 1, 0.2, 0, 1, 0]]]
+  ]); 
+
+export default wavetables;


### PR DESCRIPTION
This adds in initial support for wavetables, and sets the default wavetable to "organ".

In the next PR, I will add tools to convert waveforms and .wav files to wavetables and hopefully include a few more presets.